### PR TITLE
ORACLE Drivers

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,4 +15,15 @@ COPY gobimportclient gobimportclient
 # For the current test period, add the datafiles
 COPY example example
 
+# Copy the required db drivers
+COPY drivers drivers
+
+# Install Oracle driver
+# https://oracle.github.io/odpi/doc/installation.html#linux
+ENV ORACLE_DIR=/app/opt/oracle
+RUN mkdir -p ${ORACLE_DIR}
+RUN unzip drivers/instantclient-basic-linux.x64-18.3.0.0.0dbru.zip -d ${ORACLE_DIR}
+ENV LD_LIBRARY_PATH=${ORACLE_DIR}/instantclient_18_3:$LD_LIBRARY_PATH
+RUN apt-get install libaio1
+
 CMD ["python", "-m", "gobimportclient"]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 click==6.7
 coverage==4.5.1
+cx-Oracle==7.0.0
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2


### PR DESCRIPTION
Add Oracle drivers to connect to GOB data sources.
Most of the data sources are in Oracle databases.
For example Meetbouten.