### PR TITLE
Import Meetbouten from Grondslag

### DIFF
--- a/src/example/meetbouten_database.json
+++ b/src/example/meetbouten_database.json
@@ -28,65 +28,48 @@
 "        LEFT OUTER JOIN   grs_merken       m ON h.mer_id = m.id",
 "        LEFT OUTER JOIN   grs_status       s ON h.sta_id = s.id",
 "        WHERE  h.typ_nummer IN (7, 8)",
-"      ) WHERE rownum <= 500"
+"      ) WHERE rownum <= 5"
     ]
   },
-  "gob_model": {
+  "gob_mapping": {
     "meetboutid": {
-      "type": "GOB.String",
       "source_mapping": "meetboutid"
     },
     "nabij_adres": {
-      "type": "GOB.String",
       "source_mapping": "adres"
     },
     "locatie": {
-      "type": "GOB.String",
       "source_mapping": "locatie"
     },
     "status_id": {
-      "type": "GOB.String",
       "source_mapping": "status_id"
     },
     "status_omschrijving": {
-      "type": "GOB.String",
       "source_mapping": "status_omschrijving"
     },
     "vervaldatum": {
-      "type": "GOB.Date",
       "source_mapping": "vervaldatum",
       "format": "%Y-%m-%d"
     },
     "merk_id": {
-      "type": "GOB.String",
       "source_mapping": "merk_id"
     },
     "merk_omschrijving": {
-      "type": "GOB.String",
       "source_mapping": "merk_omschrijving"
     },
     "xmuurvlak": {
-      "type": "GOB.Decimal",
       "source_mapping": "xmuur"
     },
     "ymuurvlak": {
-      "type": "GOB.Decimal",
       "source_mapping": "ymuur"
     },
     "windrichting": {
-      "type": "GOB.String",
       "source_mapping": "windrichting"
     },
     "ligt_in_bouwblok": {
-      "type": "GOB.String",
       "source_mapping": "bouwblok_code"
     },
-    "geometrie": {
-      "type": "GOB.String",
-      "source_mapping": "geometrie"
-    },
     "publiceerbaar": {
-      "type": "GOB.Boolean",
       "source_mapping": "publiceerbaar",
       "format": "JN"
     }

--- a/src/example/meetbouten_database.json
+++ b/src/example/meetbouten_database.json
@@ -3,92 +3,92 @@
   "entity": "meetbouten",
   "entity_id": "meetboutid",
   "source": {
-    "name": "DBIMBP01",
-    "entity_id": "bout_nr",
+    "name": "Grondslag",
+    "entity_id": "meetboutid",
     "type": "database",
-    "table": "meetbout",
-    "schema": "beheerder"
+    "schema": "grondslag",
+    "query": [
+"      SELECT * FROM (",
+"      SELECT h.nummer                                                       AS meetboutid",
+"      ,      substr( h.omschrijving, 1, instr(h.omschrijving, chr(10)) -1 ) AS adres",
+"      ,      substr( h.omschrijving, instr(h.omschrijving, chr(10)) + 1 )   AS locatie",
+"      ,      h.sta_id                                                       AS status_id -- 1=actueel 2=niet te meten 3=vervallen",
+"      ,      s.omschrijving                                                 AS status_omschrijving",
+"      ,      to_char(h.vervaldatum, 'YYYY-MM-DD')                           AS vervaldatum",
+"      ,      h.mer_id                                                       AS merk_id -- 0, 1, 2, 7, 10, 14, 15, 16, 17, 20, 99",
+"      ,      m.omschr_verkort                                               AS merk_omschrijving",
+"      ,      h.xmuur                                                        AS xmuur",
+"      ,      h.ymuur                                                        AS ymuur",
+"      ,      h.windr                                                        AS windrichting",
+"      ,      k.bou_nummer                                                   AS bouwblok_code",
+"      ,      to_char(sdo_util.to_wktgeometry(h.geom))                       AS geometrie",
+"      ,      case when h.orde = 1 then 'J' else 'N' end                     AS publiceerbaar -- publiceren ja (1) of nee (0)",
+"        FROM              grs_hoogtepunten h",
+"        LEFT OUTER JOIN   grs_kringpunten  k ON h.id = k.hoo_id",
+"        LEFT OUTER JOIN   grs_merken       m ON h.mer_id = m.id",
+"        LEFT OUTER JOIN   grs_status       s ON h.sta_id = s.id",
+"        WHERE  h.typ_nummer IN (7, 8)",
+"      ) WHERE rownum <= 10"
+    ]
   },
   "gob_model": {
     "meetboutid": {
       "type": "GOB.String",
-      "source_mapping": "bout_nr"
+      "source_mapping": "meetboutid"
     },
-    "xcoordinaat": {
-      "type": "GOB.Decimal",
-      "source_mapping": "bout_xcoord",
-      "decimal_separator": ","
-    },
-    "ycoordinaat": {
-      "type": "GOB.Decimal",
-      "source_mapping": "bout_ycoord",
-      "decimal_separator": ","
+    "nabij_adres": {
+      "type": "GOB.String",
+      "source_mapping": "adres"
     },
     "locatie": {
       "type": "GOB.String",
-      "source_mapping": "bout_locatie"
+      "source_mapping": "locatie"
     },
-    "bouwblokzijde": {
+    "status_id": {
       "type": "GOB.String",
-      "source_mapping": "bout_blokzijde"
+      "source_mapping": "status_id"
     },
-    "blokeenheid": {
+    "status_omschrijving": {
       "type": "GOB.String",
-      "source_mapping": "bout_blokeenh"
+      "source_mapping": "status_omschrijving"
     },
-    "status": {
-      "type": "GOB.Character",
-      "source_mapping": "bout_status"
-    },
-    "indicatie_beveiligd": {
-      "type": "GOB.Boolean",
-      "source_mapping": "bout_beveiligd",
-      "format": "JN"
-    },
-    "eigenaar": {
-      "type": "GOB.String",
-      "source_mapping": "bout_eigenaar"
-    },
-    "nabij_ref_adressen": {
-      "type": "GOB.String",
-      "source_mapping": "bout_adres"
-    },
-    "ligt_in_ref_bouwblokken": {
-      "type": "GOB.String",
-      "source_mapping": "bout_bloknr"
-    },
-    "ligt_in_ref_stadsdelen": {
-      "type": "GOB.String",
-      "source_mapping": "bout_deelraad"
-    },
-    "hoogte_tov_nap": {
-      "type": "GOB.Decimal",
-      "source_mapping": "bout_hoogtenap",
-      "decimal_separator": ","
-    },
-    "zakking_cumulatief": {
-      "type": "GOB.Decimal",
-      "source_mapping": "bout_zakkingcum",
-      "decimal_separator": ","
-    },
-    "zakkingssnelheid": {
-      "type": "GOB.Decimal",
-      "source_mapping": "bout_zaksnelh",
-      "decimal_separator": ","
-    },
-    "datum": {
+    "vervaldatum": {
       "type": "GOB.Date",
-      "source_mapping": "bout_datum",
-      "format": "%Y%m%d"
+      "source_mapping": "vervaldatum",
+      "format": "%Y-%m-%d"
+    },
+    "merk_id": {
+      "type": "GOB.String",
+      "source_mapping": "merk_id"
+    },
+    "merk_omschrijving": {
+      "type": "GOB.String",
+      "source_mapping": "merk_omschrijving"
+    },
+    "xmuurvlak": {
+      "type": "GOB.Decimal",
+      "source_mapping": "xmuur"
+    },
+    "ymuurvlak": {
+      "type": "GOB.Decimal",
+      "source_mapping": "ymuur"
+    },
+    "windrichting": {
+      "type": "GOB.String",
+      "source_mapping": "windrichting"
+    },
+    "ligt_in_bouwblok": {
+      "type": "GOB.String",
+      "source_mapping": "bouwblok_code"
     },
     "geometrie": {
-      "type": "GOB.Geo.Point",
-      "srid": "RD",
-      "decimal_separator": ",",
-      "source_mapping": {
-        "x": "bout_xcoord",
-        "y": "bout_ycoord"
-      }
+      "type": "GOB.String",
+      "source_mapping": "geometrie"
+    },
+    "publiceerbaar": {
+      "type": "GOB.Boolean",
+      "source_mapping": "publiceerbaar",
+      "format": "JN"
     }
   }
 }

--- a/src/example/meetbouten_database.json
+++ b/src/example/meetbouten_database.json
@@ -28,7 +28,7 @@
 "        LEFT OUTER JOIN   grs_merken       m ON h.mer_id = m.id",
 "        LEFT OUTER JOIN   grs_status       s ON h.sta_id = s.id",
 "        WHERE  h.typ_nummer IN (7, 8)",
-"      ) WHERE rownum <= 10"
+"      ) WHERE rownum <= 500"
     ]
   },
   "gob_model": {

--- a/src/gobimportclient/__main__.py
+++ b/src/gobimportclient/__main__.py
@@ -13,7 +13,6 @@ import argparse
 
 from gobcore.message_broker.messagedriven_service import messagedriven_service
 from gobcore.log import get_logger
-from gobcore.model import GOBModel
 
 from gobimportclient.import_client import ImportClient
 from gobimportclient.mapping import get_mapping
@@ -32,8 +31,6 @@ args = parser.parse_args()
 
 if len(args.datasource_description) > 0:
     # If we receive a datasource as an argument, start processing the batch
-    gob_model = GOBModel()
-
     for input_name in args.datasource_description:
 
         logger.info("Reading dataset description")

--- a/src/gobimportclient/connector/config.py
+++ b/src/gobimportclient/connector/config.py
@@ -1,7 +1,7 @@
 import os
 
 DATABASE_CONFIGS = {
-    'DBIMBP01': {
+    'Grondslag': {
         'drivername': 'oracle+cx_oracle',
         'username': os.getenv("DBIMBP01_DATABASE_USER", "gob"),
         'password': os.getenv("DBIMBP01_DATABASE_PASSWORD", "insecure"),

--- a/src/gobimportclient/connector/database.py
+++ b/src/gobimportclient/connector/database.py
@@ -4,7 +4,7 @@ The following connectors are implemented in this module:
     Database - Connects to a (oracle) database using connection details
 
 """
-from sqlalchemy import create_engine, MetaData
+from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import DBAPIError
 

--- a/src/gobimportclient/connector/database.py
+++ b/src/gobimportclient/connector/database.py
@@ -30,17 +30,8 @@ def connect_to_database(source):
         engine = create_engine(URL(**DB))
         connection = engine.connect()
 
-        db_schema = source['schema']
-        table_name_suffix = f'{db_schema}.' if db_schema else ''
-        table_name = f"{table_name_suffix}{source['table']}"
-
-        # Create a metadata instance
-        metadata = MetaData(engine, schema=db_schema)
-        metadata.reflect(bind=engine, only=['meetbout'])
-
-        # Get the required table from the metadata
-        table = metadata.tables[table_name]
+        query = "\n".join(source['query'])
     except DBAPIError as e:
         raise GOBException(f'Database connection failed. Error: {e}.')
     else:
-        return connection, table
+        return connection, query

--- a/src/gobimportclient/connector/database.py
+++ b/src/gobimportclient/connector/database.py
@@ -30,8 +30,7 @@ def connect_to_database(source):
         engine = create_engine(URL(**DB))
         connection = engine.connect()
 
-        query = "\n".join(source['query'])
     except DBAPIError as e:
         raise GOBException(f'Database connection failed. Error: {e}.')
     else:
-        return connection, query
+        return connection

--- a/src/gobimportclient/converter.py
+++ b/src/gobimportclient/converter.py
@@ -7,9 +7,10 @@ Todo:
 
 """
 from gobcore.typesystem import get_gob_type
+from gobcore.model import GOBModel
 
 
-def _extract_field(row, metadata):
+def _extract_field(row, metadata, typeinfo):
     """
     Extract a field from a row given the corresponding metadata
 
@@ -36,7 +37,7 @@ def _extract_field(row, metadata):
     :param metadata:
     :return: the string value of a field specified by the field's metadata, based on the values in row
     """
-    field_type = metadata['type']
+    field_type = typeinfo['type']
     field_source = metadata['source_mapping']
 
     gob_type = get_gob_type(field_type)
@@ -64,14 +65,17 @@ def convert_data(data, dataset):
     """
     entities = []
 
-    model = dataset['gob_model']
+    gob_model = GOBModel()
+    entity_model = gob_model.get_model(dataset["entity"])["attributes"]
+
+    mapping = dataset['gob_mapping']
 
     # Extract the fields that have a source mapping defined
-    extract_fields = [field for field, meta in model.items() if 'source_mapping' in meta]
+    extract_fields = [field for field, meta in mapping.items() if 'source_mapping' in meta]
 
     for row in data:
         # extract source fields into target entity
-        target_entity = {field: _extract_field(row, model[field]) for field in extract_fields}
+        target_entity = {field: _extract_field(row, mapping[field], entity_model[field]) for field in extract_fields}
 
         # add explicit source id, as string, to target_entity
         source_id_field = dataset['source']['entity_id']

--- a/src/gobimportclient/import_client.py
+++ b/src/gobimportclient/import_client.py
@@ -33,7 +33,6 @@ class ImportClient:
         self.source = self._dataset['source']
 
         self._connection = None     # Holds the connection to the source
-        self._query = None          # Holds the SQLAlchemy query
         self._data = None           # Holds the data in imput format
         self._gob_data = None       # Holds the imported data in GOB format
 
@@ -46,7 +45,7 @@ class ImportClient:
         if self.source['type'] == "file":
             self._connection = connect_to_file(config=self.source['config'])
         elif self.source['type'] == "database":
-            self._connection, self._query = connect_to_database(self.source)
+            self._connection = connect_to_database(self.source)
         else:
             raise NotImplementedError
 
@@ -58,7 +57,7 @@ class ImportClient:
         if self.source['type'] == "file":
             self._data = read_from_file(self._connection)
         elif self.source['type'] == "database":
-            self._data = read_from_database(self._connection, self._query)
+            self._data = read_from_database(self._connection, self.source["query"])
         else:
             raise NotImplementedError
 

--- a/src/gobimportclient/import_client.py
+++ b/src/gobimportclient/import_client.py
@@ -87,7 +87,7 @@ class ImportClient:
             id_column=self._dataset['entity_id'],
             entity=self._dataset['entity'],
             version=self._dataset['version'],
-            model=self._dataset['gob_model'],
+            model={},
             timestamp=datetime.datetime.now().isoformat()
         )
 

--- a/src/gobimportclient/import_client.py
+++ b/src/gobimportclient/import_client.py
@@ -33,7 +33,7 @@ class ImportClient:
         self.source = self._dataset['source']
 
         self._connection = None     # Holds the connection to the source
-        self._table = None         # Holds the SQLAlchemy table
+        self._query = None          # Holds the SQLAlchemy query
         self._data = None           # Holds the data in imput format
         self._gob_data = None       # Holds the imported data in GOB format
 
@@ -46,7 +46,7 @@ class ImportClient:
         if self.source['type'] == "file":
             self._connection = connect_to_file(config=self.source['config'])
         elif self.source['type'] == "database":
-            self._connection, self._table = connect_to_database(self.source)
+            self._connection, self._query = connect_to_database(self.source)
         else:
             raise NotImplementedError
 
@@ -58,7 +58,7 @@ class ImportClient:
         if self.source['type'] == "file":
             self._data = read_from_file(self._connection)
         elif self.source['type'] == "database":
-            self._data = read_from_database(self._connection, self._table)
+            self._data = read_from_database(self._connection, self._query)
         else:
             raise NotImplementedError
 

--- a/src/gobimportclient/reader/database.py
+++ b/src/gobimportclient/reader/database.py
@@ -1,4 +1,4 @@
-def read_from_database(connection, table):
+def read_from_database(connection, query):
     """Reads from the database
 
     The SQLAlchemy library is used to connect to the data source for databases
@@ -6,8 +6,7 @@ def read_from_database(connection, table):
     :return: a list of data
     """
 
-    statement = table.select()
-    result = connection.execute(statement).fetchall()
+    result = connection.execute(query).fetchall()
 
     data = []
     for row in result:

--- a/src/gobimportclient/reader/database.py
+++ b/src/gobimportclient/reader/database.py
@@ -5,8 +5,7 @@ def read_from_database(connection, query):
 
     :return: a list of data
     """
-
-    result = connection.execute(query).fetchall()
+    result = connection.execute("\n".join(query)).fetchall()
 
     data = []
     for row in result:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ cx-Oracle==7.0.0
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.5#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.8#egg=gobcore
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5


### PR DESCRIPTION
Grondslag is the durable source for Meetbouten.
The import is by means of a query (join of 4 tables)

Next step is to remove the types from the mapping
rename gob_model to gob_mapping
and to remove gob_model from the message header